### PR TITLE
change target env gnueabi to gnu

### DIFF
--- a/cfg/armv5te-rcross-linux-gnueabi.json
+++ b/cfg/armv5te-rcross-linux-gnueabi.json
@@ -5,7 +5,7 @@
   "target-endian": "little",
   "target-pointer-width": "32",
   "os": "linux",
-  "env": "gnueabi",
+  "env": "gnu",
   "vendor": "unknown",
   "arch": "arm",
 


### PR DESCRIPTION
The “gnueabi” target env was changed to “gnu”: https://github.com/rust-lang/rust/pull/33403 